### PR TITLE
fixed lighthouse ability collison and removed text

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -156,7 +156,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8665980453722123373
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Gameplay Scene.unity
+++ b/Assets/Scenes/Gameplay Scene.unity
@@ -3255,13 +3255,17 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -588565113077892141, guid: 4d47d984d51b21241971d6e103d950c7, type: 3}
+      propertyPath: m_TagString
+      value: Lighthouse
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 4d47d984d51b21241971d6e103d950c7, type: 3}
       propertyPath: m_Name
       value: Lighthouse
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 4d47d984d51b21241971d6e103d950c7, type: 3}
       propertyPath: m_TagString
-      value: Townhall
+      value: Lighthouse
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:

--- a/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype 1 Ability/Protopye Projectile.cs
+++ b/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype 1 Ability/Protopye Projectile.cs
@@ -30,7 +30,7 @@ public class ProtopyeProjectile : MonoBehaviour
             other.gameObject.GetComponent<Enemy>().TakeDamage(damage);
             
         } else if (other.gameObject.tag == "Ground" ||
-                   other.gameObject.tag == "Townhall")
+                   other.gameObject.tag == "Lighthouse")
         {
             Destroy(this.gameObject);
         }

--- a/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype Burn Ability/Prototype Burn Projectile.cs
+++ b/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype Burn Ability/Prototype Burn Projectile.cs
@@ -33,7 +33,7 @@ public class ProtopyeBurnProjectile : MonoBehaviour
         }*/
 
         //AOE
-        if (other.gameObject.tag == "Enemy" || other.gameObject.tag == "Ground" || other.gameObject.tag == "Townhall")
+        if (other.gameObject.tag == "Enemy" || other.gameObject.tag == "Ground" || other.gameObject.tag == "Lighthouse")
         {
             Vector3 pos = transform.position;
             Destroy(this.gameObject);

--- a/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype Slow Ability/Prototype Slow Projectile.cs
+++ b/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype Slow Ability/Prototype Slow Projectile.cs
@@ -29,7 +29,7 @@ public class ProtopyeSlowProjectile : MonoBehaviour
             Destroy(this.gameObject);
             other.gameObject.GetComponent<Enemy>().ApplySlow(slowTime, slowMagnitude);
         } else if (other.gameObject.tag == "Ground" ||
-                   other.gameObject.tag == "Townhall")
+                   other.gameObject.tag == "Lighthouse")
         {
             Destroy(this.gameObject);
         }

--- a/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype Vulnerable Ability/Prototype Vulnerable Projectile.cs
+++ b/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype Vulnerable Ability/Prototype Vulnerable Projectile.cs
@@ -22,7 +22,7 @@ public class ProtopyeVulnerableProjectile : MonoBehaviour
             Destroy(this.gameObject);
             other.gameObject.GetComponent<Enemy>().ApplyVulnerable(duration, reductionPercentage);
         } else if (other.gameObject.tag == "Ground" ||
-                   other.gameObject.tag == "Townhall")
+                   other.gameObject.tag == "Lighthouse")
         {
             Destroy(this.gameObject);
         }

--- a/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype2 Ability/Prototype 2 Projectile.cs
+++ b/Assets/Scripts/Gameplay Scripts/Ability Scripts/Prototype2 Ability/Prototype 2 Projectile.cs
@@ -30,7 +30,7 @@ public class Protopye2Projectile : MonoBehaviour
             Destroy(this.gameObject);
             other.gameObject.GetComponent<Enemy>().ApplyFreeze(freezeTime);
         } else if (other.gameObject.tag == "Ground" ||
-                   other.gameObject.tag == "Townhall")
+                   other.gameObject.tag == "Lighthouse")
         {
             Destroy(this.gameObject);
         }

--- a/Assets/Scripts/Gameplay Scripts/Enemy Scripts/Enemy.cs
+++ b/Assets/Scripts/Gameplay Scripts/Enemy Scripts/Enemy.cs
@@ -14,6 +14,7 @@ public class Enemy : MonoBehaviour
     private float speed = DEFAULT_SPEED;
     private float damage;
     private Transform target;
+
     private bool isFrozen = false;
     private float freezeTimer = 0f;
     
@@ -43,7 +44,7 @@ public class Enemy : MonoBehaviour
     [SerializeField] private Slider healthBar;
     [SerializeField] private Image sliderBar;
     [SerializeField] private Transform healthBarTransform;
-    [SerializeField] private TextMeshProUGUI healthText;
+    [SerializeField] private TextMeshProUGUI healthText; //only needed for text over health bar for debugging
 
     private EnemySpawnManager enemySpawnManager;
 
@@ -54,7 +55,7 @@ public class Enemy : MonoBehaviour
         lighthouse = townHall.GetComponent<Lighthouse>();
         target = lighthouse.transform;
         SetRoundDamage();
-        healthText.text = health.ToString("#.0") + " / " + maxHealth.ToString("#.0");
+        //healthText.text = health.ToString("#.0") + " / " + maxHealth.ToString("#.0");
     }
 
     private void Update()
@@ -123,7 +124,7 @@ public class Enemy : MonoBehaviour
                 Die();
             }
             healthBar.value = vulnerableHealth / maxHealth;
-            healthText.text = vulnerableHealth.ToString("#.0") + " / " + maxHealth.ToString("#.0");
+            //healthText.text = vulnerableHealth.ToString("#.0") + " / " + maxHealth.ToString("#.0");
         }
         else
         {
@@ -132,7 +133,7 @@ public class Enemy : MonoBehaviour
                 Die();
             }
             healthBar.value = health / maxHealth;
-            healthText.text = health.ToString("#.0") + " / " + maxHealth.ToString("#.0");
+            //healthText.text = health.ToString("#.0") + " / " + maxHealth.ToString("#.0");
         }
     }
 
@@ -242,7 +243,7 @@ public class Enemy : MonoBehaviour
             vulnerableTimer = vulnerableTime;
             sliderBar.color = Color.green;
             healthBar.value = vulnerableHealth / maxHealth;
-            healthText.text = vulnerableHealth.ToString("#.0") + " / " + maxHealth.ToString("#.0");
+            //healthText.text = vulnerableHealth.ToString("#.0") + " / " + maxHealth.ToString("#.0");
         }
     }
 
@@ -255,7 +256,7 @@ public class Enemy : MonoBehaviour
             isVulnerable = false;
             sliderBar.color = Color.red;
             healthBar.value = health / maxHealth;
-            healthText.text = health.ToString("#.0") + " / " + maxHealth.ToString("#.0");
+            //healthText.text = health.ToString("#.0") + " / " + maxHealth.ToString("#.0");
         }
     }
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -7,6 +7,7 @@ TagManager:
   - Enemy
   - Ground
   - Townhall
+  - Lighthouse
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
* Made the abilities get destroyed on hitting the lighthouse instead of bouncing off
    - Had to change the Tag for Tower Main (child of Lighthouse)
* Removed text from enemies
    - Commented out all functions that update text and disable the text object
    - Left these in so that they can be used for debugging later in development (can be removed if not longer needed/wanted)